### PR TITLE
Add rOpenSci footer

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -141,3 +141,5 @@ These features are now implemented in `rtika`, although apparently not in `tikaR
 
 ## Code of Conduct
 Please note that this project is released with a [Contributor Code of Conduct](https://github.com/ropensci/rtika/blob/master/CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+[![ropensci\_footer](http://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/README.md
+++ b/README.md
@@ -128,3 +128,5 @@ Code of Conduct
 ---------------
 
 Please note that this project is released with a [Contributor Code of Conduct](https://github.com/ropensci/rtika/blob/master/CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+[![ropensci\_footer](http://ropensci.org/public_images/github_footer.png)](https://ropensci.org)


### PR DESCRIPTION
I always forget I'm supposed to do this when the repo transfers.