### PR TITLE
Fix for sys 2.0: no longer shQuote on Windows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^\.Rproj\.user$
 ^java
 ^\.travis\.yml$
+^appveyor.yml$
 ^README\.Rmd$
 ^tika-example$
 ^codecov\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
 Maintainer: Sasha Goodman <goodmansasha@gmail.com>
 Imports: 
     curl,
-    sys,
+    sys (>= 2.0),
     stats,
     utils, 
     rappdirs,

--- a/R/tika.R
+++ b/R/tika.R
@@ -344,23 +344,6 @@ tika <- function(input,
     maxFileSizeBytes <- c("-maxFileSizeBytes", as.character(as.integer(max_file_size)))
   }
 
-  if (.Platform$OS.type == "windows") {
-    # Windows java requires quoting for paths
-    # but OS X and Ubuntu java run into problems with shQuote.
-    java_args <- c(
-      "-Djava.awt.headless=true",
-      "-jar", shQuote(jar),
-      numConsumers,
-      maxRestarts,
-      timeoutThresholdMillis,
-      maxFileSizeBytes,
-      args,
-      output_flag,
-      "-i", shQuote(root),
-      "-o", shQuote(output_dir),
-      "-fileList", shQuote(fileList)
-    )
-  } else {
     java_args <- c(
       "-Djava.awt.headless=true",
       "-jar", jar,
@@ -372,7 +355,6 @@ tika <- function(input,
       "-o", output_dir,
       "-fileList", fileList
     )
-  }
 
   # Compared to system2, sys is somehow much quicker when making the call to java.
   # TODO: catch java errors better.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+environment:
+  global:
+    USE_RTOOLS: true
+  matrix:
+    - R_VERSION: stable
+      R_ARCH: x64
+    - R_VERSION: patched
+      R_ARCH: x64
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits


### PR DESCRIPTION
The new version of `sys` automatically quotes arguments on Windows when needed. Unfortunately this breaks the `shQuote()` workaround. You need to remove the  `shQuote()` otherwise the arguments will be double quoted.

Could you help me check if this now works with sys 2.0?

I'm sorry for the breaking change, but at least now the system calls are consistent on all platforms ;)