### PR TITLE
Fix intermittent failures on Linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
 Maintainer: Sasha Goodman <goodmansasha@gmail.com>
 Imports: 
     curl,
-    sys (>= 2.0),
+    sys (>= 2.1),
     stats,
     utils, 
     rappdirs,
@@ -35,3 +35,4 @@ RoxygenNote: 6.1.0
 URL: http://github.com/ropensci/rtika
 BugReports: http://github.com/ropensci/rtika/issues
 VignetteBuilder: knitr
+Remotes: jeroen/sys

--- a/R/tika.R
+++ b/R/tika.R
@@ -361,7 +361,7 @@ tika <- function(input,
 
   sys::exec_wait(
     cmd = java[1], args = java_args, std_out = !quiet,
-    std_err = !quiet
+    std_err = !quiet, std_in = FALSE
   )
 
   # retrieve results  --------------------------------------------------------


### PR DESCRIPTION
I added an option that restores the old behavior of 'sys' wrt closing stdin.